### PR TITLE
Stop on 401 and 403

### DIFF
--- a/crates/client/src/job.rs
+++ b/crates/client/src/job.rs
@@ -266,7 +266,7 @@ impl JobClient for HttpJobClient {
                 .call()
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(401, ..)) => State::Fail(
+                Err(UreqError::Status(401 | 403, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),

--- a/crates/client/src/job.rs
+++ b/crates/client/src/job.rs
@@ -1,5 +1,8 @@
 use super::error::ClientError;
-use crate::{error::RetryableError, pool::ClientPool};
+use crate::{
+    error::{FatalError, RetryableError},
+    pool::ClientPool,
+};
 use config::Config;
 use ctx::{Background, Ctx};
 use error_stack::{Report, Result, ResultExt};
@@ -263,6 +266,11 @@ impl JobClient for HttpJobClient {
                 .call()
             {
                 Ok(res) => State::Done(res),
+                Err(UreqError::Status(401, ..)) => State::Fail(
+                    Report::new(FatalError)
+                        .attach_printable("Unauthorized")
+                        .change_context(ClientError),
+                ),
                 Err(UreqError::Transport(err))
                     if err.kind() == ureq::ErrorKind::ConnectionFailed =>
                 {

--- a/crates/client/src/runner.rs
+++ b/crates/client/src/runner.rs
@@ -118,7 +118,7 @@ impl RunnerClient for HttpRunnerClient {
                 .call()
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(403, ..)) => State::Fail(
+                Err(UreqError::Status(401, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),
@@ -172,7 +172,7 @@ impl RunnerClient for HttpRunnerClient {
                 .call()
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(403, ..)) => State::Fail(
+                Err(UreqError::Status(401, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),
@@ -231,7 +231,7 @@ impl RunnerClient for HttpRunnerClient {
                 .send_json(ureq::json!(PollRequest { capacity }))
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(403, ..)) => State::Fail(
+                Err(UreqError::Status(401, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),
@@ -291,7 +291,7 @@ impl RunnerClient for HttpRunnerClient {
                 .send_json(ureq::json!(CompleteRequest { job_id }))
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(403, ..)) => State::Fail(
+                Err(UreqError::Status(401, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),

--- a/crates/client/src/runner.rs
+++ b/crates/client/src/runner.rs
@@ -118,7 +118,7 @@ impl RunnerClient for HttpRunnerClient {
                 .call()
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(401, ..)) => State::Fail(
+                Err(UreqError::Status(401 | 403, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),
@@ -172,7 +172,7 @@ impl RunnerClient for HttpRunnerClient {
                 .call()
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(401, ..)) => State::Fail(
+                Err(UreqError::Status(401 | 403, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),
@@ -231,7 +231,7 @@ impl RunnerClient for HttpRunnerClient {
                 .send_json(ureq::json!(PollRequest { capacity }))
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(401, ..)) => State::Fail(
+                Err(UreqError::Status(401 | 403, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),
@@ -291,7 +291,7 @@ impl RunnerClient for HttpRunnerClient {
                 .send_json(ureq::json!(CompleteRequest { job_id }))
             {
                 Ok(res) => State::Done(res),
-                Err(UreqError::Status(401, ..)) => State::Fail(
+                Err(UreqError::Status(401 | 403, ..)) => State::Fail(
                     Report::new(FatalError)
                         .attach_printable("Unauthorized")
                         .change_context(ClientError),

--- a/crates/worker/src/shell/execution_context.rs
+++ b/crates/worker/src/shell/execution_context.rs
@@ -106,7 +106,7 @@ mod tests {
     use super::*;
     use client::job::TimelineRequestStepState;
     use jobengine::{JobMeta, ProjectMeta, WorkflowMeta, WorkflowRevisionMeta};
-    use std::{collections::BTreeMap, env, sync::Arc};
+    use std::{collections::BTreeMap, sync::Arc};
     use uuid::Uuid;
 
     #[test]


### PR DESCRIPTION
This pull request includes several changes to the error handling and context management in the `client` and `runner` crates, as well as adding new tests for the `poll_loop` function.

### Error Handling Improvements:
* Updated `impl JobClient for HttpJobClient` to handle `401 Unauthorized` errors in addition to `403 Forbidden` errors by returning a `FatalError` with a printable message.
* Updated `impl RunnerClient for HttpRunnerClient` to handle `401 Unauthorized` errors in addition to `403 Forbidden` errors by returning a `FatalError` with a printable message. [[1]](diffhunk://#diff-6b7025eb73f35089feab1c89c12a3d49623708336c9375641a98f06a06c822dfL121-R121) [[2]](diffhunk://#diff-6b7025eb73f35089feab1c89c12a3d49623708336c9375641a98f06a06c822dfL175-R175) [[3]](diffhunk://#diff-6b7025eb73f35089feab1c89c12a3d49623708336c9375641a98f06a06c822dfL234-R234) [[4]](diffhunk://#diff-6b7025eb73f35089feab1c89c12a3d49623708336c9375641a98f06a06c822dfL294-R294)

### Context Management Enhancements:
* Refactored context management in `crates/runner/src/lib.rs` to create separate background contexts for different operations (`wait_ctx`, `poll_ctx`, `result_ctx`) derived from a root context (`root_ctx`). [[1]](diffhunk://#diff-705dc395e4bfb5521ca85ef0e7552261acd97eb23a372ed81bdfa909a875bb1dR99-R111) [[2]](diffhunk://#diff-705dc395e4bfb5521ca85ef0e7552261acd97eb23a372ed81bdfa909a875bb1dL154-R164)

### Testing:
* Added a new test module in `crates/runner/src/lib.rs` to test the `poll_loop` function, ensuring it exits correctly after encountering a `FatalError`.

### Code Cleanup:
* Removed unnecessary import of `env` in the test module of `crates/worker/src/shell/execution_context.rs`.