### PR TITLE
Include envs in jobengine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -811,6 +811,7 @@ dependencies = [
  "miette",
  "serde",
  "serde_json",
+ "templ",
  "uuid",
 ]
 
@@ -1933,7 +1934,6 @@ dependencies = [
  "jobengine",
  "mockall",
  "shlex",
- "templ",
  "time",
  "tracing",
  "uuid",

--- a/crates/jobengine/Cargo.toml
+++ b/crates/jobengine/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { version = "^1" }
 cellang = { version = "^0.4" }
 error-stack = "^0.5"
 miette = { version = "^7", features = ["fancy"] }
+templ = { path = "../templ" }
 
 [dev-dependencies]
 miette = { version = "^7", features = ["fancy"] }

--- a/crates/jobengine/src/lib.rs
+++ b/crates/jobengine/src/lib.rs
@@ -14,8 +14,10 @@ pub struct Config {
     /// The name of the job from which the evaluation is done
     pub name: String,
     /// Variables associated with the workflow
+    #[serde(default)]
     pub vars: BTreeMap<String, String>,
     /// Workflow environment variables
+    #[serde(default)]
     pub envs: BTreeMap<String, String>,
     /// Custom inputs
     pub inputs: Option<BTreeMap<String, InputValue>>,

--- a/crates/jobengine/src/lib.rs
+++ b/crates/jobengine/src/lib.rs
@@ -15,6 +15,8 @@ pub struct Config {
     pub name: String,
     /// Variables associated with the workflow
     pub vars: BTreeMap<String, String>,
+    /// Workflow environment variables
+    pub envs: BTreeMap<String, String>,
     /// Custom inputs
     pub inputs: Option<BTreeMap<String, InputValue>>,
     /// Scans associated with the workflow
@@ -312,6 +314,7 @@ mod tests {
             id,
             name: name.to_string(),
             vars: BTreeMap::new(),
+            envs: BTreeMap::new(),
             inputs: None,
             scans,
             project: ProjectMeta { id: Uuid::now_v7() },

--- a/crates/jobengine/src/lib.rs
+++ b/crates/jobengine/src/lib.rs
@@ -740,4 +740,27 @@ mod tests {
             .expect("expected inputs.key_bool to exist");
         assert_eq!(result, Value::Bool(true));
     }
+
+    #[test]
+    fn test_eval_templ() {
+        let mut scan_jobs = BTreeMap::new();
+        scan_jobs.insert("scan1".to_string(), vec![]);
+        let mut cfg = test_config(Uuid::now_v7(), "scan1", scan_jobs);
+        cfg.vars
+            .insert("EXAMPLE_KEY".to_string(), "EXAMPLE_VALUE".to_string());
+        let engine = JobEngine::new(&cfg);
+
+        let expr = "test str";
+        let got = engine
+            .eval_templ(expr)
+            .unwrap_or_else(|_| panic!("failed to evaluate template: {expr}"));
+        assert_eq!(expr, got);
+
+        let expr = "input has '${{ vars.EXAMPLE_KEY }}' value";
+        let got = engine
+            .eval_templ(expr)
+            .unwrap_or_else(|_| panic!("failed to evaluate template: {expr}"));
+        let want = "input has 'EXAMPLE_VALUE' value";
+        assert_eq!(want, got);
+    }
 }

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -17,7 +17,6 @@ shlex = "1.3.0"
 time = "^0.3"
 client = { path = "../client" }
 ctx = { path = "../ctx" }
-templ = { path = "../templ" }
 artifact = { path = "../artifact" }
 jobengine = { path = "../jobengine" }
 

--- a/crates/worker/src/shell/execution_context.rs
+++ b/crates/worker/src/shell/execution_context.rs
@@ -1,6 +1,7 @@
 use cellang::Value as CelValue;
 use client::job::{TimelineRequestStepOutcome, TimelineRequestStepState};
-use jobengine::JobEngine;
+use error_stack::Result;
+use jobengine::{EvaluationError, JobEngine};
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -14,6 +15,7 @@ pub struct ExecutionContext {
 }
 
 impl ExecutionContext {
+    #[tracing::instrument]
     pub fn new(workdir: String, envs: Arc<Vec<(String, String)>>, cfg: jobengine::Config) -> Self {
         let engine = JobEngine::new(&cfg);
 
@@ -32,9 +34,15 @@ impl ExecutionContext {
         ));
         envs.push(("BOUNTYHUB_JOB_ID".to_string(), cfg.id.to_string()));
         envs.push(("BOUNTYHUB_SCAN_NAME".to_string(), cfg.name.clone()));
-        cfg.envs
-            .iter()
-            .for_each(|(k, v)| envs.push((k.clone(), v.clone())));
+
+        for (k, v) in &cfg.envs {
+            match engine.eval_templ(v) {
+                Ok(v) => envs.push((k.clone(), v)),
+                Err(e) => {
+                    tracing::warn!("Failed to parse environment variable {k}: {e:?}. Continuing")
+                }
+            };
+        }
 
         Self {
             workdir,
@@ -61,8 +69,13 @@ impl ExecutionContext {
     }
 
     #[tracing::instrument(skip(self))]
-    pub fn eval(&self, expr: &str) -> Result<CelValue, String> {
-        self.engine.eval(expr).map_err(|err| format!("{:?}", err))
+    pub fn eval_expr(&self, expr: &str) -> Result<CelValue, EvaluationError> {
+        self.engine.eval_expr(expr)
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub fn eval_templ(&self, s: &str) -> Result<String, EvaluationError> {
+        self.engine.eval_templ(s)
     }
 
     #[inline]
@@ -195,30 +208,33 @@ mod tests {
             job_config.clone(),
         );
 
-        assert_eq!(ctx.eval("1 + 1").unwrap(), CelValue::Int(2));
+        assert_eq!(ctx.eval_expr("1 + 1").unwrap(), CelValue::Int(2));
         assert_eq!(
-            ctx.eval("scans.example[0].id").unwrap(),
+            ctx.eval_expr("scans.example[0].id").unwrap(),
             CelValue::String(job_config.scans["example"][0].id.to_string())
         );
         assert_eq!(
-            ctx.eval("project.id").unwrap(),
+            ctx.eval_expr("project.id").unwrap(),
             CelValue::String(job_config.project.id.to_string())
         );
         assert_eq!(
-            ctx.eval("workflow.id").unwrap(),
+            ctx.eval_expr("workflow.id").unwrap(),
             CelValue::String(job_config.workflow.id.to_string())
         );
         assert_eq!(
-            ctx.eval("revision.id").unwrap(),
+            ctx.eval_expr("revision.id").unwrap(),
             CelValue::String(job_config.revision.id.to_string())
         );
         assert_eq!(
-            ctx.eval("vars.key").unwrap(),
+            ctx.eval_expr("vars.key").unwrap(),
             CelValue::String("value".to_string())
         );
-        assert_eq!(ctx.eval("name").unwrap(), CelValue::String(job_config.name));
         assert_eq!(
-            ctx.eval("id").unwrap(),
+            ctx.eval_expr("name").unwrap(),
+            CelValue::String(job_config.name)
+        );
+        assert_eq!(
+            ctx.eval_expr("id").unwrap(),
             CelValue::String(job_config.id.to_string())
         );
     }

--- a/crates/worker/src/shell/execution_context.rs
+++ b/crates/worker/src/shell/execution_context.rs
@@ -32,6 +32,9 @@ impl ExecutionContext {
         ));
         envs.push(("BOUNTYHUB_JOB_ID".to_string(), cfg.id.to_string()));
         envs.push(("BOUNTYHUB_SCAN_NAME".to_string(), cfg.name.clone()));
+        cfg.envs
+            .iter()
+            .for_each(|(k, v)| envs.push((k.clone(), v.clone())));
 
         Self {
             workdir,
@@ -123,6 +126,7 @@ mod tests {
                 workflow: WorkflowMeta { id: Uuid::now_v7() },
                 revision: WorkflowRevisionMeta { id: Uuid::now_v7() },
                 vars: BTreeMap::new(),
+                envs: BTreeMap::new(),
             },
         );
         assert!(ctx.ok);
@@ -183,6 +187,7 @@ mod tests {
                 m.insert("key".to_string(), "value".to_string());
                 m
             },
+            envs: BTreeMap::new(),
         };
         let ctx = super::ExecutionContext::new(
             "workdir".to_string(),
@@ -237,6 +242,11 @@ mod tests {
                 workflow: WorkflowMeta { id: workflow_id },
                 revision: WorkflowRevisionMeta { id: revision_id },
                 vars: BTreeMap::new(),
+                envs: {
+                    let mut m = BTreeMap::new();
+                    m.insert("WORKFLOW_ENV".to_string(), "WORKFLOW_ENV".to_string());
+                    m
+                },
             },
         );
 
@@ -272,5 +282,9 @@ mod tests {
                 .clone(),
             revision_id.to_string(),
         );
+        assert_eq!(
+            got.get("WORKFLOW_ENV").expect("WORKFLOW_ENV").clone(),
+            "WORKFLOW_ENV".to_string(),
+        )
     }
 }

--- a/crates/worker/src/shell/steps.rs
+++ b/crates/worker/src/shell/steps.rs
@@ -631,6 +631,7 @@ mod tests {
             workflow: WorkflowMeta { id: Uuid::now_v7() },
             revision: WorkflowRevisionMeta { id: Uuid::now_v7() },
             vars: BTreeMap::new(),
+            envs: BTreeMap::new(),
             inputs: None,
         }
     }

--- a/crates/worker/src/shell/steps.rs
+++ b/crates/worker/src/shell/steps.rs
@@ -14,7 +14,6 @@ use std::process::{Command, Stdio};
 use std::sync::mpsc::{self, TryRecvError};
 use std::time::Duration;
 use std::{fmt, thread};
-use templ::{Template, Token};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -165,7 +164,7 @@ impl StepsRunner {
     fn should_run_step(&self, step: &Step) -> Result<bool, ExecutionError> {
         tracing::debug!("Evaluating condition for step: {step:?}");
         match step {
-            Step::Command { cond, .. } => match self.execution_ctx.eval(cond) {
+            Step::Command { cond, .. } => match self.execution_ctx.eval_expr(cond) {
                 Ok(val) => match val {
                     Value::Bool(v) => Ok(v),
                     v => Err(Report::new(ExecutionError).attach_printable(format!(
@@ -444,38 +443,14 @@ impl CommandStep<'_> {
         &self,
         ctx: Ctx<Background>,
         execution_ctx: &ExecutionContext,
-    ) -> std::result::Result<PathBuf, String> {
-        let Template { tokens } = self
-            .run
-            .parse()
-            .map_err(|e| format!("Failed to parse template: {:?}", e))?;
-
-        let mut output = String::new();
-        for token in tokens {
-            match token {
-                Token::Lit(lit) => output.push_str(&lit),
-                Token::Expr(expr) => {
-                    let value = execution_ctx.eval(&expr)?;
-
-                    let value = match value {
-                        Value::Int(val) => val.to_string(),
-                        Value::Uint(val) => val.to_string(),
-                        Value::Double(val) => val.to_string(),
-                        Value::String(val) => val.to_string(),
-                        Value::Bool(val) => val.to_string(),
-                        Value::Duration(val) => val.to_string(),
-                        Value::Timestamp(val) => val.to_string(),
-                        Value::Null => "".to_string(),
-                        val => return Err(format!("Unsupported value type: {val:?}")),
-                    };
-
-                    output.push_str(&value);
-                }
-            }
-        }
+    ) -> Result<PathBuf, ExecutionError> {
+        let code = execution_ctx
+            .eval_templ(self.run)
+            .change_context(ExecutionError)
+            .attach_printable("failed to parse code")?;
 
         if ctx.is_done() {
-            return Err("Context is done".to_string());
+            return Err(Report::new(ContextCancelledError).change_context(ExecutionError));
         }
 
         let file_path = Path::new(execution_ctx.workdir()).join(Uuid::new_v4().to_string());
@@ -483,12 +458,14 @@ impl CommandStep<'_> {
             let mut f = match File::create(&file_path) {
                 Ok(f) => f,
                 Err(err) => {
-                    return Err(err.to_string());
+                    return Err(Report::new(ExecutionError)
+                        .attach_printable(format!("Failed to crete file {file_path:?}: {err:?}")));
                 }
             };
 
-            if let Err(err) = f.write_all(output.as_bytes()) {
-                return Err(err.to_string());
+            if let Err(err) = f.write_all(code.as_bytes()) {
+                return Err(Report::new(ExecutionError)
+                    .attach_printable(format!("Failed to write bytes into a file: {err:?}")));
             }
         }
 
@@ -595,7 +572,7 @@ pub struct StepError;
 
 impl fmt::Display for StepError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "StepError")
+        write!(f, "Step error")
     }
 }
 
@@ -606,11 +583,22 @@ pub struct ExecutionError;
 
 impl fmt::Display for ExecutionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "ExecutionError")
+        write!(f, "Execution error")
     }
 }
 
 impl Context for ExecutionError {}
+
+#[derive(Debug)]
+pub struct ContextCancelledError;
+
+impl fmt::Display for ContextCancelledError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Context cancelled")
+    }
+}
+
+impl Context for ContextCancelledError {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
When the runner is started, it sources the environment variables. However, you may want to change the `BOUNTYHUB_TOKEN`, use different ones for different workflows, etc.

There is no need for users to go ssh to the machine and update the environment. As part of that effort, workflows are going to be extended with the `envs` field passed. These environment variables will override environment variables of the runner for the context of the job.