### PR TITLE
Fix sending all logs in step shell worker

### DIFF
--- a/crates/runner/src/lib.rs
+++ b/crates/runner/src/lib.rs
@@ -228,6 +228,7 @@ fn join_workers(
         }
 
         loop {
+            thread::sleep(Duration::from_millis(500));
             match worker_rx.try_recv() {
                 Ok(id_handle) => {
                     tracing::debug!("Received handle {}", id_handle.0);


### PR DESCRIPTION
This pull request includes several changes to improve the logging mechanism and thread management in the `crates/worker/src/shell/step.rs` file, as well as a minor update to the `crates/runner/src/lib.rs` file. The most important changes include introducing a new `push_logs` function, modifying the log handling logic, and adding thread sleeping to reduce CPU usage.

Improvements to logging and thread management:

* [`crates/worker/src/shell/step.rs`](diffhunk://#diff-672785032ee258916fe847b8bb821c55f6525e7297c070c06cac6b7b119dd618R739-R774): Introduced a new `push_logs` function to handle log pushing in a separate thread, improving code readability and maintainability.
* [`crates/worker/src/shell/step.rs`](diffhunk://#diff-672785032ee258916fe847b8bb821c55f6525e7297c070c06cac6b7b119dd618L260-R261): Replaced the inline log pushing logic with a call to the new `push_logs` function, simplifying the `log_pusher` thread creation.
* [`crates/worker/src/shell/step.rs`](diffhunk://#diff-672785032ee258916fe847b8bb821c55f6525e7297c070c06cac6b7b119dd618R323-R340): Added thread joining and error handling for `stdout_handle`, `stderr_handle`, and `log_pusher` to ensure proper thread management and error logging.
* [`crates/worker/src/shell/step.rs`](diffhunk://#diff-672785032ee258916fe847b8bb821c55f6525e7297c070c06cac6b7b119dd618L389-L403): Removed redundant thread joining and error handling code, as it is now handled in a centralized location.

Minor update:

* [`crates/runner/src/lib.rs`](diffhunk://#diff-705dc395e4bfb5521ca85ef0e7552261acd97eb23a372ed81bdfa909a875bb1dR231): Added a sleep duration in the `join_workers` function to reduce CPU usage during the loop.