### PR TITLE
Cancel job and move capacity calculation to the back-end

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "sudoservice",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "worker",
 ]
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -25,3 +25,4 @@ client = { path = "../client" }
 ctx = { path = "../ctx" }
 runner = { path = "../runner" }
 worker = { path = "../worker" }
+uuid = { version = "^1" }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -2,7 +2,6 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::{Shell, generate};
 use client::bountyhub::{BountyHubClient, RegistrationRequest, ReleaseResponse};
 use client::client_set::ClientSet;
-use client::runner::JobAcquiredResponse;
 use client::worker::HttpWorkerClient;
 use ctx::{Background, Ctx};
 use miette::{IntoDiagnostic, Result, WrapErr, bail};
@@ -13,6 +12,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use sudoservice::service::Service;
 use sudoservice::systemd::{Config as SystemdConfig, Systemd};
+use uuid::Uuid;
 use worker::shell::ShellWorker;
 
 pub(crate) mod prompt;
@@ -314,12 +314,12 @@ struct WorkerBuilder {
 impl runner::WorkerBuilder for WorkerBuilder {
     type Worker = ShellWorker<HttpWorkerClient>;
 
-    fn build(&self, job: JobAcquiredResponse) -> Result<Self::Worker> {
+    fn build(&self, id: Uuid, token: String) -> Result<Self::Worker> {
         Ok(ShellWorker {
             root_workdir: self.config.get()?.workdir.clone(),
             envs: Arc::clone(&self.envs),
-            client: self.client_set.worker_client(&job.token),
-            job,
+            client: self.client_set.worker_client(&token),
+            id,
         })
     }
 }

--- a/crates/worker/src/shell/mod.rs
+++ b/crates/worker/src/shell/mod.rs
@@ -1,12 +1,12 @@
 use self::execution_context::ExecutionContext;
 use super::Worker;
-use client::runner::JobAcquiredResponse;
 use client::worker::{Step, WorkerClient};
 use ctx::{Background, Ctx};
 use miette::{Result, WrapErr};
 use std::path::PathBuf;
 use std::sync::Arc;
 use step::{CommandStep, SetupStep, Step as ShellStep, TeardownStep, UploadStep};
+use uuid::Uuid;
 
 pub mod execution_context;
 pub mod step;
@@ -19,7 +19,7 @@ where
     pub root_workdir: PathBuf,
     pub envs: Arc<Vec<(String, String)>>,
     pub client: C,
-    pub job: JobAcquiredResponse,
+    pub id: Uuid,
 }
 
 impl<C> Worker for ShellWorker<C>
@@ -28,7 +28,7 @@ where
 {
     #[tracing::instrument(skip(self, ctx))]
     fn run(self, ctx: Ctx<Background>) -> Result<()> {
-        tracing::info!("Resolving job {}", self.job.id);
+        tracing::info!("Resolving job {}", self.id);
         let job = self
             .client
             .resolve(ctx.clone())


### PR DESCRIPTION
Job cancellation wouldn't be propagated until the log propagation fails.
This change moves capacity calculation to the back-end as well as includes the job cancellation message.